### PR TITLE
database.ymlの更新

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -50,5 +50,6 @@ test:
 production:
   <<: *default
   database: freemarket_sample_60b_production
-  username: freemarket_sample_60b
-  password: <%= ENV['FREEMARKET_SAMPLE_60B_DATABASE_PASSWORD'] %>
+  username: root
+  password: <%= ENV['DATABASE_PASSWORD'] %>
+  socket: /var/lib/mysql/mysql.sock


### PR DESCRIPTION
# What
・mysqlの設定を本番環境と同様の状態に変更

# Why
・本番環境でインストールするmysqlの設定がローカルとは異なり、mysqlへ接続できなくなっている状態を解消するため