### PR TITLE
【WIP】【マークアップ】【サーバーサイド】購入確定画面の実装

### DIFF
--- a/app/assets/stylesheets/purchase/_purchase.scss
+++ b/app/assets/stylesheets/purchase/_purchase.scss
@@ -101,8 +101,9 @@
                 }
               }
             }
+
           }
-          .buy-button{
+          .payjp-button{
             background-color: #ea352d;
             border: 1px solid #ea352d;
             color: #fff;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,7 @@ class ItemsController < ApplicationController
     card: params['payjp-token'],
     currency: 'jpy'
     )
+    redirect_to root_path, notice: '決済が完了しました'
   end
 
   private

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -82,7 +82,7 @@
 
 
     .item__buy-btn
-      = link_to '購入画面に進む', "/items/:id/purchase", class:"item__buy-btn"
+      = link_to '購入画面に進む', "/items/:id/purchase", class:"item__buy-btn", "data-turbolinks": false
 
 
     .item-introduction

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -5,7 +5,7 @@
   .item-box-container
     %h1.item-name
       COACH コーチ ショルダーバッグ✩9日(水)昼12時までの値段
-      
+
     .item-main-content
       .item__photos
         = image_tag 'https://static.mercdn.net/item/detail/orig/photos/m94173632764_1.jpg?1569882243', class:"item__main-photo"
@@ -44,7 +44,7 @@
                 %li
                   = link_to 'https://www.mercari.com/jp/category/20/', class:"list__category" do
                     = fa_icon 'chevron-right'
-                    バッグ 
+                    バッグ
                 %li
                   = link_to 'https://www.mercari.com/jp/category/214/', class:"list__category" do
                     = fa_icon 'chevron-right'
@@ -53,7 +53,7 @@
             %th ブランド
             %td
               = link_to 'コーチ', 'https://www.mercari.com/jp/brand/539/', class:"td__brand"
-              
+
           %tr
             %th 商品の状態
             %td やや傷や汚れあり
@@ -82,11 +82,11 @@
 
 
     .item__buy-btn
-      = link_to '購入画面に進む', '#', class:"item__buy-btn"
+      = link_to '購入画面に進む', "/items/:id/purchase", class:"item__buy-btn"
 
 
     .item-introduction
-      %p 
+      %p
         長々とした、いいね！はしないで下さい。
         ショルダーバック
         ブラウン

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
   root 'items#index'
   resources :items do
     collection do
-      get 'purchase'
+      # get 'purchase'
       get 'sell'
       get  'done'
       post 'pay'
@@ -14,6 +14,14 @@ Rails.application.routes.draw do
       # 後で 'pay/:id'に修正する。工藤
     end
   end
+
+  resources :items do
+    member do
+      get :purchase
+    end
+end
+
+
 
   resources :users, only: [:index, :update] do
     collection do


### PR DESCRIPTION
## WHAT
・購入内容確認ページ(items/purchase)の「購入する」ボタンにページ移動の機能実装、cssの修正
・購入内容確認ページ(items/purchase)の「カードで支払う」ボタンを押すと購入終了ページへ移動するように実装
・購入終了ページのマークアップ、「商品一覧ページに戻る」リンクの実装


## WHY
・商品詳細→購入→購入確定→商品一覧ページへの移動の流れを実装するため