### PR TITLE
【WIP】追加作成したページにパンくずリストの実装

### DIFF
--- a/app/assets/stylesheets/modules/users.scss
+++ b/app/assets/stylesheets/modules/users.scss
@@ -9,7 +9,12 @@ body{
 a{
   text-decoration: none;
 }
-
+.container__left{
+  display: flex;
+  margin: 40px auto 0;
+  width: 1020px;
+  padding-bottom: 40px;
+}
 .container-mypage{
   display: flex;
   width: 1020px;

--- a/app/views/users/_bread-crumbs.html.haml
+++ b/app/views/users/_bread-crumbs.html.haml
@@ -9,3 +9,19 @@
     - breadcrumb :mypage_profile
     = breadcrumbs separator: " &nbsp;&nbsp;&#12297;&nbsp; "
 
+  - when ['users', 'selling']
+    - breadcrumb :mypage_listing
+    = breadcrumbs separator: " &nbsp;&nbsp;&#12297;&nbsp; "
+
+  - when ['users', 'progression']
+    - breadcrumb :mypage_progression
+    = breadcrumbs separator: " &nbsp;&nbsp;&#12297;&nbsp; "
+
+  - when ['users', 'completion']
+    - breadcrumb :mypage_completion
+    = breadcrumbs separator: " &nbsp;&nbsp;&#12297;&nbsp; "
+
+  - when ['items', 'detail']
+    - breadcrumb :mypage_listing_item
+    = breadcrumbs separator: " &nbsp;&nbsp;&#12297;&nbsp; "
+

--- a/app/views/users/completion.html.haml
+++ b/app/views/users/completion.html.haml
@@ -1,56 +1,57 @@
 = render partial: '/items/header', locals: { }
+= render partial: '/users/bread-crumbs', locals: { }
 
 .wrapper-profile
   .container__left
     = render partial: "side_bar"
-  .wrapper-contener
-    .mypage-tab-container
-      %h2.mypage-tab-head 出品した商品
-      %ul.status-tabs
-        %li.status
-          %h3.status__name
-            = link_to selling_users_path, class: "status-link" do
-              出品中
-        %li.status
-          %h3.status__name
-            = link_to progression_users_path, class: "status-link" do
-              取引中
-        %li.status-active
-          %h3.status__name
-            = link_to completion_users_path, class: "status-link" do
-              売却済み
-      .tab-content
-        %ul#mypage-tab-transaction-now.mypage-item-list.tab-pane.active
-          - if @items.present?
-            - @items.each do |item|
-              %li.selling-item
-                = link_to "", class: "mypage-item-link" do
-                  = image_tag "#{item.image}", class: "selling-item-image"
-                  .mypage-item-body
-                    .mypage-item-upper
-                      = item.name
-                    .mypage-item-lower
-                      %span.selling-item-count
-                        = fa_icon "heart", class: "selling-icon-heart"
-                        %span 0
-                      %span.selling-item-count
-                        = fa_icon "comment", class: "selling-icon-comment"
-                        %span 0
-                      .mypage-item-status.completion
-                        売却済
-                  = fa_icon "angle-right", class: "icon-arrow-right"
-          - else
-            .empty-status
-              = image_tag "https://www.mercari.com/jp/assets/img/common/common/logo-gray-icon.svg?35731317", class: "empty-status__logo"
-              .empty-status__text
-                売却済みの商品がありません
-    %ul.mypage-history
-      %li.pager-prev.pager-cell
-        = link_to "", class: "prev-button" do
-          = fa_icon "angle-left", class: "icon-arrow-left"
-      %li.pager-next.pager-cell
-        = link_to "", class: "next-button" do
-          = fa_icon "angle-right", class: "icon-arrow-right"
+    .wrapper-contener
+      .mypage-tab-container
+        %h2.mypage-tab-head 出品した商品
+        %ul.status-tabs
+          %li.status
+            %h3.status__name
+              = link_to selling_users_path, class: "status-link" do
+                出品中
+          %li.status
+            %h3.status__name
+              = link_to progression_users_path, class: "status-link" do
+                取引中
+          %li.status-active
+            %h3.status__name
+              = link_to completion_users_path, class: "status-link" do
+                売却済み
+        .tab-content
+          %ul#mypage-tab-transaction-now.mypage-item-list.tab-pane.active
+            - if @items.present?
+              - @items.each do |item|
+                %li.selling-item
+                  = link_to "", class: "mypage-item-link" do
+                    = image_tag "#{item.image}", class: "selling-item-image"
+                    .mypage-item-body
+                      .mypage-item-upper
+                        = item.name
+                      .mypage-item-lower
+                        %span.selling-item-count
+                          = fa_icon "heart", class: "selling-icon-heart"
+                          %span 0
+                        %span.selling-item-count
+                          = fa_icon "comment", class: "selling-icon-comment"
+                          %span 0
+                        .mypage-item-status.completion
+                          売却済
+                    = fa_icon "angle-right", class: "icon-arrow-right"
+            - else
+              .empty-status
+                = image_tag "https://www.mercari.com/jp/assets/img/common/common/logo-gray-icon.svg?35731317", class: "empty-status__logo"
+                .empty-status__text
+                  売却済みの商品がありません
+      %ul.mypage-history
+        %li.pager-prev.pager-cell
+          = link_to "", class: "prev-button" do
+            = fa_icon "angle-left", class: "icon-arrow-left"
+        %li.pager-next.pager-cell
+          = link_to "", class: "next-button" do
+            = fa_icon "angle-right", class: "icon-arrow-right"
 
 
 = render partial: '/items/aside', locals: { }

--- a/app/views/users/progression.html.haml
+++ b/app/views/users/progression.html.haml
@@ -1,56 +1,57 @@
 = render partial: '/items/header', locals: { }
+= render partial: '/users/bread-crumbs', locals: { }
 
 .wrapper-profile
   .container__left
     = render partial: "side_bar"
-  .wrapper-contener
-    .mypage-tab-container
-      %h2.mypage-tab-head 出品した商品
-      %ul.status-tabs
-        %li.status
-          %h3.status__name
-            = link_to selling_users_path, class: "status-link" do
-              出品中
-        %li.status-active
-          %h3.status__name
-            = link_to progression_users_path, class: "status-link" do
-              取引中
-        %li.status
-          %h3.status__name
-            = link_to completion_users_path, class: "status-link" do
-              売却済み
-      .tab-content
-        %ul#mypage-tab-transaction-now.mypage-item-list.tab-pane.active
-          - if @items.present?
-            - @items.each do |item|
-              %li.selling-item
-                = link_to "", class: "mypage-item-link" do
-                  = image_tag "#{item.image}", class: "selling-item-image"
-                  .mypage-item-body
-                    .mypage-item-upper
-                      = item.name
-                    .mypage-item-lower
-                      %span.selling-item-count
-                        = fa_icon "heart", class: "selling-icon-heart"
-                        %span 0
-                      %span.selling-item-count
-                        = fa_icon "comment", class: "selling-icon-comment"
-                        %span 0
-                      .mypage-item-status
-                        取引中
-                  = fa_icon "angle-right", class: "icon-arrow-right"
-          - else
-            .empty-status
-              = image_tag "https://www.mercari.com/jp/assets/img/common/common/logo-gray-icon.svg?35731317", class: "empty-status__logo"
-              .empty-status__text
-                取引中の商品がありません
-    %ul.mypage-history
-      %li.pager-prev.pager-cell
-        = link_to "", class: "prev-button" do
-          = fa_icon "angle-left", class: "icon-arrow-left"
-      %li.pager-next.pager-cell
-        = link_to "", class: "next-button" do
-          = fa_icon "angle-right", class: "icon-arrow-right"
+    .wrapper-contener
+      .mypage-tab-container
+        %h2.mypage-tab-head 出品した商品
+        %ul.status-tabs
+          %li.status
+            %h3.status__name
+              = link_to selling_users_path, class: "status-link" do
+                出品中
+          %li.status-active
+            %h3.status__name
+              = link_to progression_users_path, class: "status-link" do
+                取引中
+          %li.status
+            %h3.status__name
+              = link_to completion_users_path, class: "status-link" do
+                売却済み
+        .tab-content
+          %ul#mypage-tab-transaction-now.mypage-item-list.tab-pane.active
+            - if @items.present?
+              - @items.each do |item|
+                %li.selling-item
+                  = link_to "", class: "mypage-item-link" do
+                    = image_tag "#{item.image}", class: "selling-item-image"
+                    .mypage-item-body
+                      .mypage-item-upper
+                        = item.name
+                      .mypage-item-lower
+                        %span.selling-item-count
+                          = fa_icon "heart", class: "selling-icon-heart"
+                          %span 0
+                        %span.selling-item-count
+                          = fa_icon "comment", class: "selling-icon-comment"
+                          %span 0
+                        .mypage-item-status
+                          取引中
+                    = fa_icon "angle-right", class: "icon-arrow-right"
+            - else
+              .empty-status
+                = image_tag "https://www.mercari.com/jp/assets/img/common/common/logo-gray-icon.svg?35731317", class: "empty-status__logo"
+                .empty-status__text
+                  取引中の商品がありません
+      %ul.mypage-history
+        %li.pager-prev.pager-cell
+          = link_to "", class: "prev-button" do
+            = fa_icon "angle-left", class: "icon-arrow-left"
+        %li.pager-next.pager-cell
+          = link_to "", class: "next-button" do
+            = fa_icon "angle-right", class: "icon-arrow-right"
 
 
 = render partial: '/items/aside', locals: { }

--- a/app/views/users/selling.html.haml
+++ b/app/views/users/selling.html.haml
@@ -1,56 +1,57 @@
 = render partial: '/items/header', locals: { }
+= render partial: '/users/bread-crumbs', locals: { }
 
 .wrapper-profile
   .container__left
     = render partial: "side_bar"
-  .wrapper-contener
-    .mypage-tab-container
-      %h2.mypage-tab-head 出品した商品
-      %ul.status-tabs
-        %li.status-active
-          %h3.status__name
-            = link_to selling_users_path, class: "status-link" do
-              出品中
-        %li.status
-          %h3.status__name
-            = link_to progression_users_path, class: "status-link" do
-              取引中
-        %li.status
-          %h3.status__name
-            = link_to completion_users_path, class: "status-link" do
-              売却済み
-      .tab-content
-        %ul#mypage-tab-transaction
-          - if @items.present?
-            - @items.each do |item|
-              %li.selling-item
-                = link_to detail_item_path(item), class: "mypage-item-link" do
-                  = image_tag "#{item.images[0].image}", class: "selling-item-image"
-                  .mypage-item-body
-                    .mypage-item-upper
-                      = item.name
-                    .mypage-item-lower
-                      %span.selling-item-count
-                        = fa_icon "heart", class: "selling-icon-heart"
-                        %span 0
-                      %span.selling-item-count
-                        = fa_icon "comment", class: "selling-icon-comment"
-                        %span 0
-                      .mypage-item-status
-                        出品中
-                  = fa_icon "angle-right", class: "icon-arrow-right"
-          - else
-            .empty-status
-              = image_tag "https://www.mercari.com/jp/assets/img/common/common/logo-gray-icon.svg?35731317", class: "empty-status__logo"
-              .empty-status__text
-                出品中の商品がありません
-    %ul.mypage-history
-      %li.pager-prev.pager-cell
-        = link_to "", class: "prev-button" do
-          = fa_icon "angle-left", class: "icon-arrow-left"
-      %li.pager-next.pager-cell
-        = link_to "", class: "next-button" do
-          = fa_icon "angle-right", class: "icon-arrow-right"
+    .wrapper-contener
+      .mypage-tab-container
+        %h2.mypage-tab-head 出品した商品
+        %ul.status-tabs
+          %li.status-active
+            %h3.status__name
+              = link_to selling_users_path, class: "status-link" do
+                出品中
+          %li.status
+            %h3.status__name
+              = link_to progression_users_path, class: "status-link" do
+                取引中
+          %li.status
+            %h3.status__name
+              = link_to completion_users_path, class: "status-link" do
+                売却済み
+        .tab-content
+          %ul#mypage-tab-transaction
+            - if @items.present?
+              - @items.each do |item|
+                %li.selling-item
+                  = link_to detail_item_path(item), class: "mypage-item-link" do
+                    = image_tag "#{item.images[0].image}", class: "selling-item-image"
+                    .mypage-item-body
+                      .mypage-item-upper
+                        = item.name
+                      .mypage-item-lower
+                        %span.selling-item-count
+                          = fa_icon "heart", class: "selling-icon-heart"
+                          %span 0
+                        %span.selling-item-count
+                          = fa_icon "comment", class: "selling-icon-comment"
+                          %span 0
+                        .mypage-item-status
+                          出品中
+                    = fa_icon "angle-right", class: "icon-arrow-right"
+            - else
+              .empty-status
+                = image_tag "https://www.mercari.com/jp/assets/img/common/common/logo-gray-icon.svg?35731317", class: "empty-status__logo"
+                .empty-status__text
+                  出品中の商品がありません
+      %ul.mypage-history
+        %li.pager-prev.pager-cell
+          = link_to "", class: "prev-button" do
+            = fa_icon "angle-left", class: "icon-arrow-left"
+        %li.pager-next.pager-cell
+          = link_to "", class: "next-button" do
+            = fa_icon "angle-right", class: "icon-arrow-right"
 
 
 = render partial: '/items/aside', locals: { }

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -13,17 +13,17 @@ crumb :mypage_logout do
 end
 
 crumb :mypage_listing do
-  link '出品した商品-出品中', root_path
+  link '出品した商品-出品中',selling_users_path
   parent :mypage
 end
 
 crumb :mypage_progression do
-  link '出品した商品-取引中', root_path
+  link '出品した商品-取引中', progression_users_path
   parent :mypage
 end
 
 crumb :mypage_completion do
-  link '出品した商品-売却済', root_path
+  link '出品した商品-売却済', completion_users_path
   parent :mypage
 end
 
@@ -51,3 +51,9 @@ crumb :mypage_identification do
   link '本人情報', root_path
   parent :mypage
 end
+
+crumb :mypage_listing_item do
+  link '商品出品画面', detail_item_path
+  parent :mypage_listing
+end
+


### PR DESCRIPTION
## WHAT
・追加作成したページsellingページ、progressionページ、completionページにパンくずリストの追加
・viewの調整

## WHY
・自分が現在どのページにいるのかを知らせるため