### PR TITLE
商品一覧及び商品詳細機能の実装（カテゴリー・ユーザーごとの商品一覧表示）

### DIFF
--- a/app/assets/stylesheets/modules/_show-item.scss
+++ b/app/assets/stylesheets/modules/_show-item.scss
@@ -372,11 +372,11 @@
     }
   }
 
-  // ユーザーのその他の出品紹介
-  .item__in-user-boxes {
+  // 出品したユーザー・同じ商品種類のその他の出品一覧
+  .item__in-another-boxes {
     width: 700px;
     margin: 0 auto;
-    .item__user-name {
+    .item__another-name {
       font-size: 22px;
       font-weight: bold;
       margin: 24px 0 8px;
@@ -386,18 +386,22 @@
         text-decoration: none;
       }
     }
-    .item__user-other-items {
+    .item__another-items {
       width: 700px;
-      height: 350px;
+      height: 700px;
       display: flex;
-      .item-box {
+      flex-wrap: wrap;
+      justify-content: space-between;
+      .another-item-box {
         width: 220px;
-        margin: 0 20px 20px 0;
+        height: 330px;
+        color: black;
+        margin-bottom:20px;
         &__photo {
           width: 220px;
           height: 220px;
         }
-        &__body {
+        .item-box__body {
           height: 110px;
           padding: 16px;
           background-color: #fff;
@@ -415,64 +419,22 @@
     }
   }
 
-  // 同じ商品種類のその他の出品紹介
-  .item__in-another-boxes {
-    width: 700px;
-    margin: 0 auto;
-    .tameshi {
-      width: 100%;
-      margin-right: 24px;
-
-      .item__another-name {
-        font-size: 22px;
-        font-weight: bold;
-        margin: 24px 0 8px;
-        line-height: 1.4;
-        &__title {
-          color: #0099E8;
-          text-decoration: none;
-        }
-      }
-      .item__another-items {
-        width: 700px;
-        height: 700px;
-        display: flex;
-        flex-wrap: wrap;
-        justify-content: space-between;
-        .another-item-box {
-          width: 220px;
-          height: 330px;
-          margin-bottom:20px;
-          &__photo {
-            width: 220px;
-            height: 220px;
-          }
-          .item-box__body {
-            height: 110px;
-            padding: 16px;
-            background-color: #fff;
-            .item-box__name {
-              font-size: 16px;
-              height: 48px;
-            }
-            .item__numbers {
-              display: flex;
-              margin-top: 8px;
-              justify-content: space-between;
-            }
-          }
-        }
-      }
-    }
-  }
-
   .nav-bottom {
     border-top: 1px solid #eee;
-    &__name {
-      width: 700px;
+    ul {
+      display: block;
+      width: 1020px;
       margin: 0 auto;
-      padding: 16px 0;
-      font-size: 14px;
+      line-height: 48px;
+      display: flex;
+      .nav-bottom__name {
+        color: black;
+        padding: 16px 0;
+        font-size: 14px;
+      }
+      .nav-icon-right {
+        margin-right: 5px;
+      }
     }
   }
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -43,6 +43,7 @@ class ItemsController < ApplicationController
 
   def show
     @total_price = @item.total_price.to_s(:delimited)
+    @user_items = Item.where(seller_id: @item.seller).where.not(id: @item.id).order("created_at DESC").limit(6)
   end
 
   def edit

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,11 +8,15 @@ class ItemsController < ApplicationController
     @items = Item.order("created_at DESC").limit(10)
     
     # カテゴリーごとの商品表示
-    @ladies_items = Item.where(category_id: 1..199).order("created_at DESC").limit(10)
-    @mens_items = Item.where(category_id: 200..345).order("created_at DESC").limit(10)
-    @electrical_appliance_items = Item.where(category_id: 898..983).order("created_at DESC").limit(10)
-    @toy_hobby_items = Item.where(category_id: 685..797).order("created_at DESC").limit(10)
+    @lady_category = Category.find(1)
+    @men_category = Category.find(200)
+    @electrical_category = Category.find(898)
+    @toy_category = Category.find(685)
 
+    @ladies_items = Item.where(category_id: @lady_category.indirect_ids).order("created_at DESC").limit(10)
+    @mens_items = Item.where(category_id: @men_category.indirect_ids).order("created_at DESC").limit(10)
+    @electrical_appliance_items = Item.where(category_id: @electrical_category.indirect_ids).order("created_at DESC").limit(10)
+    @toy_hobby_items = Item.where(category_id: @toy_category.indirect_ids).order("created_at DESC").limit(10)
   end
 
   def purchase

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,15 @@ class ItemsController < ApplicationController
   after_action :buyer_add, only: [:pay]
 
   def index
+    # ブランドはまだ未実装なので、とりあえず全ての商品を表示させる
     @items = Item.order("created_at DESC").limit(10)
+    
+    # カテゴリーごとの商品表示
+    @ladies_items = Item.where(category_id: 1..199).order("created_at DESC").limit(10)
+    @mens_items = Item.where(category_id: 200..345).order("created_at DESC").limit(10)
+    @electrical_appliance_items = Item.where(category_id: 898..983).order("created_at DESC").limit(10)
+    @toy_hobby_items = Item.where(category_id: 685..797).order("created_at DESC").limit(10)
+
   end
 
   def purchase
@@ -34,7 +42,6 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @images = @item.images
     @total_price = @item.total_price.to_s(:delimited)
   end
 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -31,15 +31,15 @@
             =fa_icon 'chevron-right'
         .item-index
           .items
-            - @items.each do |item|
+            - @ladies_items.each do |la_item|
               .item
-                = link_to item_path(item), class: "item-link" do
-                  = image_tag "#{item.images[0].image}", class:"item__image"
+                = link_to item_path(la_item), class: "item-link" do
+                  = image_tag "#{la_item.images[0].image}", class:"item__image"
                   %span.item__price
-                    = "¥#{item.total_price.to_s(:delimited)}"
+                    = "¥#{la_item.total_price.to_s(:delimited)}"
                   .item__name
                     %span.item__name__text
-                      = item.name
+                      = la_item.name
         .items__genre__title
           %h3.items__genre__title__text
             メンズ新着アイテム
@@ -48,15 +48,15 @@
             =fa_icon 'chevron-right'
         .item-index
           .items
-            - @items.each do |item|
+            - @mens_items.each do |me_item|
               .item
-                = link_to item_path(item), class: "item-link" do
-                  = image_tag "#{item.images[0].image}", class:"item__image"
+                = link_to item_path(me_item), class: "item-link" do
+                  = image_tag "#{me_item.images[0].image}", class:"item__image"
                   %span.item__price
-                    = "¥#{item.total_price.to_s(:delimited)}"
+                    = "¥#{me_item.total_price.to_s(:delimited)}"
                   .item__name
                     %span.item__name__text
-                      = item.name
+                      = me_item.name
         .items__genre__title
           %h3.items__genre__title__text
             家電・スマホ・カメラ新着アイテム
@@ -65,15 +65,15 @@
             =fa_icon 'chevron-right'
         .item-index
           .items
-            - @items.each do |item|
+            - @electrical_appliance_items.each do |el_item|
               .item
-                = link_to item_path(item), class: "item-link" do
-                  = image_tag "#{item.images[0].image}", class:"item__image"
+                = link_to item_path(el_item), class: "item-link" do
+                  = image_tag "#{el_item.images[0].image}", class:"item__image"
                   %span.item__price
-                    = "¥#{item.total_price.to_s(:delimited)}"
+                    = "¥#{el_item.total_price.to_s(:delimited)}"
                   .item__name
                     %span.item__name__text
-                      = item.name
+                      = el_item.name
         .items__genre__title
           %h3.items__genre__title__text
             おもちゃ・ホビー・グッズ新着アイテム
@@ -82,15 +82,15 @@
             =fa_icon 'chevron-right'
         .item-index
           .items
-            - @items.each do |item|
+            - @toy_hobby_items.each do |to_item|
               .item
-                = link_to item_path(item), class: "item-link" do
-                  = image_tag "#{item.images[0].image}", class:"item__image"
+                = link_to item_path(to_item), class: "item-link" do
+                  = image_tag "#{to_item.images[0].image}", class:"item__image"
                   %span.item__price
-                    = "¥#{item.total_price.to_s(:delimited)}"
+                    = "¥#{to_item.total_price.to_s(:delimited)}"
                   .item__name
                     %span.item__name__text
-                      = item.name
+                      = to_item.name
 
   .popularity-index
     %h2.index-genre

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -174,119 +174,102 @@
       %li
         = fa_icon 'pinterest', class:"pinterest"
 
-  .item__in-user-boxes
-    .item__user-name
-      = link_to "#{@item.seller.nick_name}さんのその他の出品", '#', class:"item__user-name__title"
-    .item__user-other-items
-      .item-box
-        =image_tag 'https://static.mercdn.net/thumb/photos/m34261125424_1.jpg?1569881404', class:"item-box__photo"
+  .item__in-another-boxes
+    .item__another-name
+      = link_to "#{@item.seller.nick_name}さんのその他の出品", '#', class:"item__another-name__title"
+    .item__another-items
+      - @user_items.each do |user_item|
+        = link_to item_path(user_item) do
+          .another-item-box
+            =image_tag "#{user_item.images[0].image}", class:"another-item-box__photo"
+            .item-box__body
+              .item-box__name
+                = user_item.name
+              .item__numbers
+                .item__price
+                  = "¥#{user_item.total_price.to_s(:delimited)}"
+                .item__iine
+                  = fa_icon 'heart-o'
+                  6
+
+  .item__in-another-boxes
+    .item__another-name
+      = link_to 'コーチのショルダーバッグその他の出品', '#', class:"item__another-name__title"
+    .item__another-items
+      .another-item-box
+        =image_tag 'https://static.mercdn.net/thumb/photos/m61354018553_1.jpg?1570595655', class:"another-item-box__photo"
         .item-box__body
           .item-box__name
-            COACH✩2wayバック✩値下げ4日金曜までの値段
+            COACHショルダーバッグ
           .item__numbers
             .item__price
-              ¥7,500
+              ¥7,900
             .item__iine
               = fa_icon 'heart-o'
               6
-      .item-box
-        =image_tag 'https://static.mercdn.net/thumb/photos/m60502397332_1.jpg?1566786201', class:"item-box__photo"
+      .another-item-box
+        =image_tag 'https://static.mercdn.net/thumb/photos/m56026905237_1.jpg?1568313448', class:"another-item-box__photo"
         .item-box__body
           .item-box__name
-            マーティンネックレス10/8火曜昼12時まで限定
+            コーチ / COACH / シグネチャー/ショルダーバッグ
           .item__numbers
             .item__price
               ¥3,780
             .item__iine
               = fa_icon 'heart-o'
-              5
-      .item-box
-        =image_tag 'https://static.mercdn.net/thumb/photos/m34261125424_1.jpg?1569881404', class:"item-box__photo"
+              10
+      .another-item-box
+        =image_tag "https://static.mercdn.net/thumb/photos/m54851888084_1.jpg?1570678345", class:"another-item-box__photo"
         .item-box__body
           .item-box__name
-            COACH✩2wayバック✩値下げ4日金曜までの値段
+            鑑定済 COACH コーチ ショルダーバッグ
           .item__numbers
             .item__price
-              ¥7,500
+              ¥6,500
             .item__iine
               = fa_icon 'heart-o'
-              6
-
-  .item__in-another-boxes
-    .tameshi
-      .item__another-name
-        = link_to 'コーチのショルダーバッグその他の出品', '#', class:"item__another-name__title"
-      .item__another-items
-        .another-item-box
-          =image_tag 'https://static.mercdn.net/thumb/photos/m61354018553_1.jpg?1570595655', class:"another-item-box__photo"
-          .item-box__body
-            .item-box__name
-              COACHショルダーバッグ
-            .item__numbers
-              .item__price
-                ¥7,900
-              .item__iine
-                = fa_icon 'heart-o'
-                6
-        .another-item-box
-          =image_tag 'https://static.mercdn.net/thumb/photos/m56026905237_1.jpg?1568313448', class:"another-item-box__photo"
-          .item-box__body
-            .item-box__name
-              コーチ / COACH / シグネチャー/ショルダーバッグ
-            .item__numbers
-              .item__price
-                ¥3,780
-              .item__iine
-                = fa_icon 'heart-o'
-                10
-        .another-item-box
-          =image_tag "https://static.mercdn.net/thumb/photos/m54851888084_1.jpg?1570678345", class:"another-item-box__photo"
-          .item-box__body
-            .item-box__name
-              鑑定済 COACH コーチ ショルダーバッグ
-            .item__numbers
-              .item__price
-                ¥6,500
-              .item__iine
-                = fa_icon 'heart-o'
-                8
-        .another-item-box
-          =image_tag 'https://static.mercdn.net/thumb/photos/m92349942579_1.jpg?1570692919', class:"another-item-box__photo"
-          .item-box__body
-            .item-box__name
-              COACH‼️シグネチアキャンバス(^^)
-            .item__numbers
-              .item__price
-                ¥8,500
-              .item__iine
-                = fa_icon 'heart-o'
-                4
-        .another-item-box
-          =image_tag 'https://static.mercdn.net/thumb/photos/m89330509639_1.jpg?1570632116', class:"another-item-box__photo"
-          .item-box__body
-            .item-box__name
-              ショルダーバッグ COACH コーチ
-            .item__numbers
-              .item__price
-                ¥4,780
-              .item__iine
-                = fa_icon 'heart-o'
-                5
-        .another-item-box
-          =image_tag 'https://static.mercdn.net/thumb/photos/m78411505604_1.jpg?1570715951', class:"another-item-box__photo"
-          .item-box__body
-            .item-box__name
-              コーチ ショルダーバッグ
-            .item__numbers
-              .item__price
-                ¥6,500
-              .item__iine
-                = fa_icon 'heart-o'
-                1
+              8
+      .another-item-box
+        =image_tag 'https://static.mercdn.net/thumb/photos/m92349942579_1.jpg?1570692919', class:"another-item-box__photo"
+        .item-box__body
+          .item-box__name
+            COACH‼️シグネチアキャンバス(^^)
+          .item__numbers
+            .item__price
+              ¥8,500
+            .item__iine
+              = fa_icon 'heart-o'
+              4
+      .another-item-box
+        =image_tag 'https://static.mercdn.net/thumb/photos/m89330509639_1.jpg?1570632116', class:"another-item-box__photo"
+        .item-box__body
+          .item-box__name
+            ショルダーバッグ COACH コーチ
+          .item__numbers
+            .item__price
+              ¥4,780
+            .item__iine
+              = fa_icon 'heart-o'
+              5
+      .another-item-box
+        =image_tag 'https://static.mercdn.net/thumb/photos/m78411505604_1.jpg?1570715951', class:"another-item-box__photo"
+        .item-box__body
+          .item-box__name
+            コーチ ショルダーバッグ
+          .item__numbers
+            .item__price
+              ¥6,500
+            .item__iine
+              = fa_icon 'heart-o'
+              1
 
   .nav-bottom
-    .nav-bottom__name
-      メルカリ > COACH コーチ ショルダーバッグ✩9日(水)昼12時までの値段
+    %ul
+      %li
+        = link_to "メルカリ", root_path, class:"nav-bottom__name"
+        = fa_icon "chevron-right", class:"nav-icon-right"
+      %li
+        = @item.name
 
 = render partial: '/items/aside', locals: { }
 = render partial: '/items/footer', locals: { }


### PR DESCRIPTION
# What
・商品一覧ページで、カテゴリごとに新着商品を分けて表示できるようにする
・商品詳細ページで、その商品を出品したユーザーが出品した別の商品の一覧が表示できるようにする

# Why
・ユーザーが商品を検索する際の利便性を高めるため
