### PR TITLE
出品する商品の画像の設定変更

### DIFF
--- a/app/assets/stylesheets/items/_detail.scss
+++ b/app/assets/stylesheets/items/_detail.scss
@@ -24,8 +24,6 @@
 .item-detail-wrapper {
   background-color: #f5f5f5;
   width: 100vw;
-  height: 100vh;
-  overflow: scroll;
   font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
 
   // 商品購入情報全体

--- a/app/assets/stylesheets/items/_edit.scss
+++ b/app/assets/stylesheets/items/_edit.scss
@@ -33,26 +33,6 @@
           &__box{
             width: 620px;
             margin: 16px auto 0;
-            &__items-nothing{
-            }
-            &__items-have{
-              width: 100%;
-              padding: 40px;
-              position: relative;
-              min-height: 162px;
-              background: #f5f5f5;
-              border: 1px dashed #ccc;
-              text-align: center;
-              display: flex;
-              justify-content: center;
-              align-items: center;
-              cursor: pointer;
-              .upload-drop-file{
-                width: 100%;
-                height: 100%;
-              }
-              
-            }
           }
         }
         .sell-content{

--- a/app/assets/stylesheets/modules/_show-item.scss
+++ b/app/assets/stylesheets/modules/_show-item.scss
@@ -1,8 +1,6 @@
 .item-detail-wrapper {
   background-color: #f5f5f5;
   width: 100vw;
-  height: 100vh;
-  overflow: scroll;
   font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
 
   // 商品購入情報全体

--- a/app/assets/stylesheets/purchase/_edit.scss
+++ b/app/assets/stylesheets/purchase/_edit.scss
@@ -1,8 +1,6 @@
 .item-detail-wrapper {
   background-color: #f5f5f5;
   width: 100vw;
-  height: 100vh;
-  overflow: scroll;
   font-family: 'Source Sans Pro', Helvetica , Arial, '游ゴシック体', 'YuGothic', 'メイリオ', 'Meiryo', sans-serif;
 
   // 商品購入情報全体

--- a/app/assets/stylesheets/purchase/_sell.scss
+++ b/app/assets/stylesheets/purchase/_sell.scss
@@ -33,13 +33,29 @@
           &__box{
             width: 620px;
             margin: 16px auto 0;
-            &__items-nothing{
-            }
+            text-align: center;
+            display: flex;
+            justify-content: center;
+            align-items: center;
             &__items-have{
-              .upload-drop-file{
-              }
+              width: 100%;
+              padding: 80px 200px;
+              margin: 0 auto;
+              position: relative;
+              min-height: 162px;
+              background: #f5f5f5;
+              border: 1px dashed #ccc;
+              text-align: center;
+              display: flex;
+              justify-content: center;
+              align-items: center;
+              cursor: pointer;
             }
           }
+          pre{
+            margin-top: 8px;
+          }
+
         }
         .sell-content{
           padding: 40px;

--- a/app/views/items/detail.html.haml
+++ b/app/views/items/detail.html.haml
@@ -27,7 +27,7 @@
             %th
               出品者
             %td
-              = link_to current_user.nick_name, 'https://www.mercari.com/jp/mypage/', class: "td__user-name"
+              = link_to @item.seller.nick_name, 'https://www.mercari.com/jp/mypage/', class: "td__user-name"
               .item-user__information
                 .item-user__ratings
                   = fa_icon 'laugh',class:"icon-good"

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -7,23 +7,6 @@
         .sell-container__inner
           %h2.sell-container__inner__title 商品の情報を入力
           = form_for @item, html: {class: "sell-form"} do |f|
-            .sell-upload
-              %h3.sell-upload__head
-                出品画像
-                %span.form-require 必須
-              %p.sell-upload__text 最大10枚までアップロードできます
-              .sell-upload__box
-                .sell-upload__box__items-nothing
-                  .sell-upload-items
-                    %ul
-                .sell-upload__box__items-have
-                  = f.label :images do
-                    = f.fields_for :images do |f_image|
-                      = f_image.file_field :image, type: "file", multiple: true,  name: "item[images_attributes][][image]", class: "upload-drop-file"
-                  %pre
-                    :preserve
-                      ドラッグアンドドロップ
-                      またはクリックしてファイルをアップロード
             .sell-content
               .form-group
                 %label.form-group__name

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -13,16 +13,14 @@
                 %span.form-require 必須
               %p.sell-upload__text 最大10枚までアップロードできます
               .sell-upload__box
-                .sell-upload__box__items-nothing
-                  .sell-upload-items
-                    %ul
-                .sell-upload__box__items-have
-                  = f.fields_for :images do |f_image|
-                    = f_image.file_field :image, type: "file", multiple: true,  name: "item[images_attributes][][image]", class: "upload-drop-file"
-                  %pre
-                    :preserve
-                      ドラッグアンドドロップ
-                      またはクリックしてファイルをアップロード
+                .sell-upload-items
+                  %ul
+                = f.fields_for :images do |f_image|
+                  = f_image.file_field :image, type: "file", multiple: true,  name: "item[images_attributes][][image]", class: "upload-drop-file sell-upload__box__items-have"
+              %pre
+                :preserve
+                  クリックしてファイルをアップロード
+                  複数枚アップロードする際はドラッグしてください
             .sell-content
               .form-group
                 %label.form-group__name


### PR DESCRIPTION
## What
　商品出品時「画像をドラッグアンドドロップでアップロード」の記述を消す
　商品編集時画像の編集ボックスを出さない
## Why
　画像をドラッグアンドドロップでアップロードする機能の実装が間に合わないと判断したため
　画像の編集機能が間に合わないと判断したため