### PR TITLE
細かいビューの修正

### DIFF
--- a/app/assets/javascripts/top-page.js
+++ b/app/assets/javascripts/top-page.js
@@ -1,0 +1,8 @@
+$(document).on("turbolinks:load", function(){
+  $('.genre__wrapper__list').click(function(){
+    var i = $(".genre__wrapper__list").index(this)
+    var p = $(".items__genre__title__text").eq(i).offset().top;
+    $('html,body').animate({ scrollTop: p }, 'swing');
+    return false;
+  });
+});

--- a/app/views/items/purchase.html.haml
+++ b/app/views/items/purchase.html.haml
@@ -34,32 +34,38 @@
           %h3.buy-content__inner__index
             配送先
           %address.buy-user-info-text
-            〒000-0000
+            = "〒#{@item.seller.postal_code}"
             %br/
-            東京都渋谷区○○○○○○○○○○○○
+            = @item.seller.prefectures
+            %span
+            = @item.seller.city
+            %span
+            = @item.seller.address
+            %span
+            = @item.seller.building_name
             %br/
-            メル・カリー
+            = @item.seller.family_name
+            %span
+            = @item.seller.last_name
           %p.buy-user-info-text
           = link_to "", class: "buy-user-info-fix" do
             .change
               変更する
               %span ＞
-            -# =fa_icon 'chevron-right', class: "change-icon"
       .buy-content.buy-user-info.bottom
         .buy-content__inner
           %h3.buy-content__inner__index
             支払方法
           %p.buy-user-info-text
-            ***********0000
+            ***********4242
             %br/
-            00/00
+            10/22
             %br/
             = image_tag "//www-mercari-jp.akamaized.net/assets/img/card/american_express.svg?2296184308", class: "card-icon"
           = link_to "", class: "buy-user-info-fix" do
             .change
               変更する
               %span ＞
-            -# =fa_icon 'chevron-right', class: "change-icon"
   = render partial: '/shared/single-footer', locals: { }
 
 

--- a/app/views/shared/_single-footer.html.haml
+++ b/app/views/shared/_single-footer.html.haml
@@ -10,7 +10,7 @@
       %li
         = link_to "https://www.mercari.com/jp/tokutei/", class: "footer-link" do
           特定商取引に関する表記
-  = link_to "https://www.mercari.com/jp/", class: "single-footer__link" do
+  = link_to "/", class: "single-footer__link" do
     = image_tag "//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?3466462615", class: "single-footer__link__logo"
   %p.copyright__text
     © 2019 Mercari

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -8,7 +8,12 @@ crumb :category do
 end
 
 crumb :mypage do
-  link 'マイページ', user_path(current_user)
+  @user = User.find(params[:id])
+  if @user.id == current_user.id
+    link 'マイページ', user_path(current_user)
+  else
+    link @user.nick_name, user_path(@user)
+  end
   parent :root
 end
 


### PR DESCRIPTION
## What
　ビュー修正（購入確認、フッター、トップページ、マイページ）
　購入確認ページの住所のダミーをDBの情報に差し替える
　footerのリンク先をトップページにする
　トップページのカテゴリーにスムーススクロールをつける
　users#showのパンくずをそれぞれのユーザーのnick_nameにする
## Why
　購入確認ページの住所がダミーデータのままだったため
　存在しないページへのリンク先が指定されていたため
　新規商品（カテゴリー）の下の方へ楽に移動させるため
　どのユーザーのページへ行っても”マイページ”の表記だったため