### PR TITLE
トップページにログイン時・ログアウト時のnoticeを表示

### DIFF
--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,5 +1,9 @@
 = render partial: 'items/header', locals: { }
 
+-if flash[:notice]
+  .flash-notice
+    = flash[:notice]
+
 .main-contents
   = image_tag "https://web-jp-assets.mercdn.net/_next/static/images/top-banner-camp-4f3fd88c685e8932d7dde2ad3a8336ba.jpg", class: "back-image"
   .popularity-index


### PR DESCRIPTION
## What
　ログイン・ログアウト時にトップページにnoticeを入れる
## Why
　商品編集ページにnoticeを入れており、初めてログインした状態でそのページに行くと「ログインしました」と表示される。ログインした場合トップページに遷移するので、トップページに「ログインしました」というnoticeを入れた方がいいと判断したため。